### PR TITLE
corrigindo erro do CORS

### DIFF
--- a/src/main/java/com/erifas/backend/resource/controller/AdministradorController.java
+++ b/src/main/java/com/erifas/backend/resource/controller/AdministradorController.java
@@ -1,9 +1,11 @@
 package com.erifas.backend.resource.controller;
 
 import com.erifas.backend.service.AdministradorService;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@CrossOrigin(origins = "http://localhost:3000")
 public class AdministradorController {
 
     private final AdministradorService administradorService;

--- a/src/main/java/com/erifas/backend/resource/controller/BilheteController.java
+++ b/src/main/java/com/erifas/backend/resource/controller/BilheteController.java
@@ -13,6 +13,7 @@ import java.util.Optional;
 
 @RestController
 @RequestMapping("/bilhete")
+@CrossOrigin(origins = "http://localhost:3000")
 public class BilheteController {
     private final BilheteService bilheteService;
 

--- a/src/main/java/com/erifas/backend/resource/controller/CompradorController.java
+++ b/src/main/java/com/erifas/backend/resource/controller/CompradorController.java
@@ -3,13 +3,11 @@ package com.erifas.backend.resource.controller;
 import com.erifas.backend.persistence.model.Comprador;
 import com.erifas.backend.service.CompradorService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/comprador")
+@CrossOrigin(origins = "http://localhost:3000")
 public class CompradorController {
 
     private final CompradorService compradorService;

--- a/src/main/java/com/erifas/backend/resource/controller/CompradorController.java
+++ b/src/main/java/com/erifas/backend/resource/controller/CompradorController.java
@@ -3,7 +3,10 @@ package com.erifas.backend.resource.controller;
 import com.erifas.backend.persistence.model.Comprador;
 import com.erifas.backend.service.CompradorService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/comprador")

--- a/src/main/java/com/erifas/backend/resource/controller/CompradorController.java
+++ b/src/main/java/com/erifas/backend/resource/controller/CompradorController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.CrossOrigin;
 
 @RestController
 @RequestMapping("/comprador")

--- a/src/main/java/com/erifas/backend/resource/controller/FotoController.java
+++ b/src/main/java/com/erifas/backend/resource/controller/FotoController.java
@@ -1,9 +1,11 @@
 package com.erifas.backend.resource.controller;
 
 import com.erifas.backend.service.FotoService;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@CrossOrigin(origins = "http://localhost:3000")
 public class FotoController {
 
     private final FotoService fotoService;

--- a/src/main/java/com/erifas/backend/resource/controller/ProdutoController.java
+++ b/src/main/java/com/erifas/backend/resource/controller/ProdutoController.java
@@ -1,9 +1,11 @@
 package com.erifas.backend.resource.controller;
 
 import com.erifas.backend.service.ProdutoService;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@CrossOrigin(origins = "http://localhost:3000")
 public class ProdutoController {
 
     private final ProdutoService produtoService;

--- a/src/main/java/com/erifas/backend/resource/controller/RifaController.java
+++ b/src/main/java/com/erifas/backend/resource/controller/RifaController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/rifa")
+@CrossOrigin(origins = "http://localhost:3000")
 public class RifaController {
 
     private final RifaService rifaService;

--- a/src/main/java/com/erifas/backend/resource/controller/UsuarioController.java
+++ b/src/main/java/com/erifas/backend/resource/controller/UsuarioController.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 
 @RestController
 @RequestMapping("/usuario")
+@CrossOrigin(origins = "http://localhost:3000")
 public class UsuarioController {
 
     private final UsuarioService usuarioService;

--- a/src/main/java/com/erifas/backend/resource/controller/VendedorController.java
+++ b/src/main/java/com/erifas/backend/resource/controller/VendedorController.java
@@ -1,9 +1,11 @@
 package com.erifas.backend.resource.controller;
 
 import com.erifas.backend.service.VendedorService;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@CrossOrigin(origins = "http://localhost:3000")
 public class VendedorController {
 
     private final VendedorService vendedorService;


### PR DESCRIPTION
Atualmente quando uma requisição é feita para o backend acontece um erro de política do CORS, pois a rota do frontend não é confiável. Então, este PR apenas corrige isso, adicionando a rota do frontend nos arquivos de controlers.